### PR TITLE
BISERVER-10924 - JDBC connections to MonetDB fail when used in an analyzer report

### DIFF
--- a/pentaho-database-model/src/org/pentaho/database/dialect/MonetDatabaseDialect.java
+++ b/pentaho-database-model/src/org/pentaho/database/dialect/MonetDatabaseDialect.java
@@ -67,7 +67,7 @@ public class MonetDatabaseDialect extends AbstractDatabaseDialect {
         return getNativeJdbcPre() + databaseConnection.getDatabaseName();
       } else {
         return getNativeJdbcPre()
-            + "monetdb://" + databaseConnection.getHostname() + ":" + databaseConnection.getDatabasePort() + "/" + databaseConnection.getDatabaseName(); //$NON-NLS-1$
+            + "//" + databaseConnection.getHostname() + ":" + databaseConnection.getDatabasePort() + "/" + databaseConnection.getDatabaseName(); //$NON-NLS-1$
       }
     }
   }


### PR DESCRIPTION
BISERVER-10924 - JDBC connections to MonetDB fail when used in an analyzer report
