### PR TITLE
[BISERVER-11276] Implement Connection Pooling to respect "disabled" and ...

### DIFF
--- a/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
@@ -939,7 +939,12 @@ public class DataHandler extends AbstractXulEventHandler {
     // Pooling panel settings 
 
     if (poolingCheck != null) {
-      poolingCheck.setChecked(databaseConnection.isUsingConnectionPool());
+      //BISERVER-11276 connection pooling should default to checked
+      if( databaseConnection.getId() != null ) {
+        poolingCheck.setChecked(databaseConnection.isUsingConnectionPool());
+      } else {
+        poolingCheck.setChecked( true ); // new connection, default to true
+      }
     }
 
     // set all of the pooling properties to the defaults


### PR DESCRIPTION
..."enabled" pools at the same time

```
- "Enable Connection Pooling" checkbox defaults to 'checked' (on creation)
- implemented DinamicallyPooledOrJndiDatasourceService that delegates to a pooled / nonPooled DatasourceService depending on databaseConnection.isUsingConnectionPool()
- implemented DinamicallyPooledDatasourceSystemListener to handle pooling / nonPooling depending on databaseConnection.isUsingConnectionPool()
- connection pooling properties implemented: testOnBorrow, testWhileIdle, testOnReturn, defaultReadOnly, defaultAutoCommit, defaultTransactionIsolation, defaultCatalog, poolPreparedStatements, maxOpenPreparedStatements, accessToUnderlyingConnectionAllowed, timeBetweenEvictionRunsMillis, removeAbandoned, removeAbandonedTimeout, logAbandoned
```
