### PR TITLE
BISERVER-12185 - Vertica port hard-coded to 50000 instead of 5433 on Data Access Wizard

### DIFF
--- a/pentaho-database-model/src/org/pentaho/database/dialect/Vertica5DatabaseDialect.java
+++ b/pentaho-database-model/src/org/pentaho/database/dialect/Vertica5DatabaseDialect.java
@@ -39,7 +39,7 @@ public class Vertica5DatabaseDialect extends VerticaDatabaseDialect {
    */
   private static final long serialVersionUID = -7791425035679133135L;
   private static final IDatabaseType DBTYPE = new DatabaseType( "Vertica 5+", "VERTICA5", DatabaseAccessType.getList(
-      DatabaseAccessType.NATIVE, DatabaseAccessType.ODBC, DatabaseAccessType.JNDI ), 50000, null );
+      DatabaseAccessType.NATIVE, DatabaseAccessType.ODBC, DatabaseAccessType.JNDI ), 5433, null );
 
   public Vertica5DatabaseDialect() {
   }

--- a/pentaho-database-model/src/org/pentaho/database/dialect/VerticaDatabaseDialect.java
+++ b/pentaho-database-model/src/org/pentaho/database/dialect/VerticaDatabaseDialect.java
@@ -38,7 +38,7 @@ public class VerticaDatabaseDialect extends AbstractDatabaseDialect {
   private static final long serialVersionUID = 449286268556765514L;
 
   private static final IDatabaseType DBTYPE = new DatabaseType( "Vertica", "VERTICA", DatabaseAccessType.getList(
-      DatabaseAccessType.NATIVE, DatabaseAccessType.ODBC, DatabaseAccessType.JNDI ), 50000, null );
+      DatabaseAccessType.NATIVE, DatabaseAccessType.ODBC, DatabaseAccessType.JNDI ), 5433, null );
 
   public VerticaDatabaseDialect() {
   }


### PR DESCRIPTION
@rfellows, @rmansoor, @mbatchelor couldyou review it?
for branch 5.2 https://github.com/pentaho/pentaho-commons-database/pull/61
