### PR TITLE
[BACKLOG-411]Use ThinDriver in pdi-dataservice-plugin

### DIFF
--- a/pentaho-database-model/src/org/pentaho/database/dialect/PDIDialect.java
+++ b/pentaho-database-model/src/org/pentaho/database/dialect/PDIDialect.java
@@ -54,7 +54,7 @@ public class PDIDialect extends GenericDatabaseDialect {
   }
 
   public String getNativeDriver() {
-    return "org.pentaho.di.core.jdbc.ThinDriver";
+    return "org.pentaho.di.trans.dataservice.jdbc.ThinDriver";
   }
 
   @Override


### PR DESCRIPTION
Requires https://github.com/pentaho/pentaho-platform/pull/2250

ThinDriver package name was changed during migration from kettle-core to pdi-dataservice-plugin
This updates the platform dialect to use the new ThinDriver