### PR TITLE
[BACKLOG-6547] - CDH55 secure shim: PUC: DB Table(s) Data Source cann…

### DIFF
--- a/pentaho-database-gwt/ivy.xml
+++ b/pentaho-database-gwt/ivy.xml
@@ -75,5 +75,6 @@
         <dependency org="org.hsqldb" name="hsqldb" rev="2.3.2" transitive="false" conf="test->default"/>
         <dependency org="org.apache.commons" name="commons-vfs2" rev="2.0" transitive="true" conf="test->default" />
         <dependency org="com.google.guava" name="guava" rev="17.0" transitive="false" conf="test->default"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" conf="test->default"/>
     </dependencies>
 </ivy-module>

--- a/pentaho-database-gwt/src/org/pentaho/database/util/DatabaseUtil.java
+++ b/pentaho-database-gwt/src/org/pentaho/database/util/DatabaseUtil.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.database.util;
@@ -33,6 +33,13 @@ public class DatabaseUtil {
 
     Properties props = meta.getDatabaseInterface().getAttributes();
 
+    for ( String key : conn.getAttributes().keySet() ) {
+      String val = conn.getAttributes().get( key );
+      if ( val != null ) {
+        props.put( key, val );
+      }
+    }
+
     for ( String key : conn.getExtraOptions().keySet() ) {
       if ( conn.getExtraOptions().get( key ) != null ) {
         props.put( BaseDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + key, conn.getExtraOptions().get( key ) );
@@ -43,13 +50,6 @@ public class DatabaseUtil {
       if ( conn.getConnectionPoolingProperties().get( key ) != null ) {
         props.put( BaseDatabaseMeta.ATTRIBUTE_POOLING_PARAMETER_PREFIX + key, conn.getConnectionPoolingProperties()
             .get( key ) );
-      }
-    }
-
-    for ( String key : conn.getAttributes().keySet() ) {
-      String val = conn.getAttributes().get( key );
-      if ( val != null ) {
-        props.put( key, val );
       }
     }
 
@@ -88,7 +88,7 @@ public class DatabaseUtil {
     meta.setUsingDoubleDecimalAsSchemaTableSeparator( conn.isUsingDoubleDecimalAsSchemaTableSeparator() );
 
     if ( conn.getPartitioningInformation() != null ) {
-      PartitionDatabaseMeta pdmetas[] = new PartitionDatabaseMeta[conn.getPartitioningInformation().size()];
+      PartitionDatabaseMeta[] pdmetas = new PartitionDatabaseMeta[conn.getPartitioningInformation().size()];
 
       // TODO
       int c = 0;

--- a/pentaho-database-gwt/test-src/org/pentaho/database/util/DatabaseUtilTest.java
+++ b/pentaho-database-gwt/test-src/org/pentaho/database/util/DatabaseUtilTest.java
@@ -1,0 +1,168 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.database.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Assert;
+
+import org.mockito.Mockito;
+import org.mockito.Matchers;
+
+import org.pentaho.database.model.DatabaseAccessType;
+import org.pentaho.database.model.IDatabaseConnection;
+import org.pentaho.database.model.IDatabaseType;
+import org.pentaho.di.core.database.BaseDatabaseMeta;
+import org.pentaho.di.core.database.DatabaseInterface;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.plugins.ClassLoadingPluginInterface;
+import org.pentaho.di.core.plugins.DatabasePluginType;
+import org.pentaho.di.core.plugins.Plugin;
+import org.pentaho.di.core.plugins.PluginRegistry;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DatabaseUtilTest {
+
+  private static final String DBTYPE = "DBTYPE";
+
+  @SuppressWarnings( { "unchecked", "serial" } )
+  private static void registerDBPlugin( String dbName ) throws Exception {
+    Properties props = new Properties();
+
+    DatabaseInterface dbIface = Mockito.mock( BaseDatabaseMeta.class, Mockito.withSettings().extraInterfaces( Cloneable.class ) );
+    Class<?> dbIfaceClass = dbIface.getClass();
+    Mockito.when( dbIface.getDatabaseName() ).thenReturn( dbName );
+    Mockito.when( dbIface.clone() ).thenReturn( dbIface );
+    Mockito.when( dbIface.getAttributes() ).thenReturn( props );
+    Mockito.when( dbIface.getConnectionPoolingProperties() ).thenCallRealMethod();
+    Mockito.when( dbIface.getExtraOptions() ).thenCallRealMethod();
+    Mockito.doCallRealMethod().when( dbIface ).setAttributes( Matchers.any( Properties.class ) );
+    dbIface.setAttributes( new Properties() );
+
+    final Plugin dbPlugin = Mockito.mock( Plugin.class, Mockito.withSettings().extraInterfaces( ClassLoadingPluginInterface.class ) );
+    Mockito.doReturn( dbIfaceClass ).when( dbPlugin ).getMainType();
+    Mockito.when( dbPlugin.getIds() ).thenReturn( new String[] { dbName } );
+    Mockito.when( dbPlugin.getName() ).thenReturn( dbName );
+    Mockito.when( dbPlugin.matches( dbName ) ).thenReturn( true );
+    Mockito.when( dbPlugin.getClassMap() ).thenReturn(
+        new HashMap<Class<?>, String>() { { put( dbPlugin.getClass(), "org.pentaho.di.core.database.InfobrightDatabaseMeta" ); } } );
+    Mockito.doReturn( dbIface ).when( ( (ClassLoadingPluginInterface) dbPlugin ) ).loadClass( Matchers.any( Class.class ) );
+
+    PluginRegistry.getInstance().registerPlugin(
+        DatabasePluginType.class,
+        dbPlugin );
+  }
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    PluginRegistry.init();
+    PluginRegistry.getInstance().registerPluginType( DatabasePluginType.class );
+
+    registerDBPlugin( "Oracle" );
+    registerDBPlugin( "MYSQL" );
+    registerDBPlugin( DBTYPE );
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @SuppressWarnings( "serial" )
+  @Test
+  public void testConvertToDatabaseMeta() {
+    IDatabaseConnection conn = Mockito.mock( IDatabaseConnection.class );
+
+    Map<String, String> attributes = new HashMap<String, String>() {
+      {
+        put( "ATTR_NAME_1", "ATTR_VALUE_1" );
+        put( BaseDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + DBTYPE + ".extra_opt_override", "extra_opt_override_attr" );
+        put( BaseDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + DBTYPE + ".extra_opt_no_override", "extra_opt_no_override_attr" );
+        put( BaseDatabaseMeta.ATTRIBUTE_POOLING_PARAMETER_PREFIX + "pooling_opt_override", "pooling_opt_override_attr" );
+        put( BaseDatabaseMeta.ATTRIBUTE_POOLING_PARAMETER_PREFIX + "pooling_opt_no_override", "pooling_opt_no_override_attr" );
+      }
+    };
+
+    Map<String, String> extra = new HashMap<String, String>() {
+      {
+        put( DBTYPE + ".extra_opt_override", "extra_opt_val_override_extra" );
+      }
+    };
+
+    Map<String, String> pool = new HashMap<String, String>() {
+      {
+        put( "pooling_opt_override", "pooling_opt_override_pool" );
+      }
+    };
+
+    Mockito.when( conn.getAttributes() ).thenReturn( attributes );
+    Mockito.when( conn.getExtraOptions() ).thenReturn( extra );
+    Mockito.when( conn.getConnectionPoolingProperties() ).thenReturn( pool );
+    Mockito.when( conn.getAccessType() ).thenReturn( DatabaseAccessType.NATIVE );
+
+    IDatabaseType dbType = Mockito.mock( IDatabaseType.class );
+    Mockito.when( dbType.getShortName() ).thenReturn( DBTYPE );
+    Mockito.when( conn.getDatabaseType() ).thenReturn( dbType );
+
+    DatabaseMeta meta = DatabaseUtil.convertToDatabaseMeta( conn );
+
+    Assert.assertNotNull( meta );
+
+    Properties attrs = meta.getAttributes();
+
+    // Check generic attributes
+    Assert.assertEquals( "ATTR_VALUE_1", attrs.getProperty( "ATTR_NAME_1" ) );
+
+    // Check extra attributes as part of generic with prefixes
+    Assert.assertEquals( "extra_opt_val_override_extra",
+        attrs.getProperty( BaseDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + DBTYPE + ".extra_opt_override" ) );
+    Assert.assertEquals( "extra_opt_no_override_attr",
+        attrs.getProperty( BaseDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + DBTYPE + ".extra_opt_no_override" ) );
+
+    // Check pooling attributes as part of generic with prefixes
+    Assert.assertEquals( "pooling_opt_override_pool",
+        attrs.getProperty( BaseDatabaseMeta.ATTRIBUTE_POOLING_PARAMETER_PREFIX + "pooling_opt_override" ) );
+    Assert.assertEquals( "pooling_opt_no_override_attr",
+        attrs.getProperty( BaseDatabaseMeta.ATTRIBUTE_POOLING_PARAMETER_PREFIX + "pooling_opt_no_override" ) );
+
+    // Check pooling attributes as a separate set w/o prefixes
+    Properties poolProps = meta.getConnectionPoolingProperties();
+    Assert.assertEquals( "pooling_opt_override_pool", poolProps.getProperty( "pooling_opt_override" ) );
+    Assert.assertEquals( "pooling_opt_no_override_attr", poolProps.getProperty( "pooling_opt_no_override" ) );
+
+    // Check extra attributes as a separate set w/o prefixes
+    Map<String, String> extraProps = meta.getExtraOptions();
+    Assert.assertEquals( "extra_opt_val_override_extra", extraProps.get( DBTYPE + ".extra_opt_override" ) );
+    Assert.assertEquals( "extra_opt_no_override_attr", extraProps.get( DBTYPE + ".extra_opt_no_override" ) );
+  }
+
+}


### PR DESCRIPTION
…ot be created based on Secured Cloudera Impala JDBC connection

the issue is caused by the fact that two different sets of "extra" properties could be stored for a db connection in BI repository:
the first is under extraOptions node (BI style)
the second is in attributes collection with EXTRA_OPTION_ prefix (DI style)

The Database Dialog displays and changes the BI style options, while a real connection is established using the DI style one.
In order to fix this the DatabaseUtil.convertToDatabaseMeta() method is changed so that BI style options has higher precidence.
Checkstyle is fixed for the affected sources.
Unit Test is provided (ivy.xml has been chenged to resolve Mockito library)

@hudak @tkafalas @e-cuellar would you mind to review