### PR TITLE
[PDI-15260] Model built using Spoon Agile is not getting published to the BA server

### DIFF
--- a/pentaho-database-model/src/org/pentaho/database/service/DatabaseDialectService.java
+++ b/pentaho-database-model/src/org/pentaho/database/service/DatabaseDialectService.java
@@ -16,8 +16,6 @@
  */
 package org.pentaho.database.service;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.pentaho.database.IDatabaseDialect;
 import org.pentaho.database.IDatabaseDialectProvider;
 import org.pentaho.database.IDriverLocator;
@@ -33,10 +31,11 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class DatabaseDialectService implements IDatabaseDialectService {
-  private static final Log logger = LogFactory.getLog( DatabaseDialectService.class );
   private static final List<IDatabaseDialectProvider> providers = Collections.unmodifiableList(
-    StreamSupport.stream( ServiceLoader.load( IDatabaseDialectProvider.class ).spliterator(), false ).collect(
-      Collectors.toList() ) );
+          StreamSupport
+                  .stream( ServiceLoader.load( IDatabaseDialectProvider.class,
+                          DatabaseDialectService.class.getClassLoader() ).spliterator(), false )
+                  .collect( Collectors.toList() ) );
 
   private final boolean isOnlyReturnAvailable;
 


### PR DESCRIPTION
When publishing model from agile-bi we are [creating an instance of DatabaseDialectService](https://github.com/pentaho/pdi-agile-bi-plugin/blob/master/src/org/pentaho/agilebi/spoon/publish/ModelServerPublish.java#L341) class.

But we run into [ServiceConfigurationError](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceConfigurationError.html) wrapped into NoClassDeffoundError because static fields cannot be initialized properly.

It happens because `ServiceLoader#load(Class<S> service)` loads classes with the help of `Thread.currentThread().getContextClassLoader()` classloader.
Thats not what we want here, as DatabaseDialectService and other pentaho-database-model classes are loaded via [Kettels own classloader] (https://github.com/pentaho/pentaho-kettle/blob/master/core/src/org/pentaho/di/core/plugins/KettleURLClassLoader.java), that is a child of thread's content classloader.
So we enforce ServiceLoader to load classes from the same classloader, that DatabaseDialectService class was loaded from.

I also removed Logger, as it is not used anywhere.