### PR TITLE
[SP-2762] Backport of PDI-15260 - Model built using Spoon Agile is not getting published to the BA server. (6.1 Suite)

### DIFF
--- a/pentaho-database-model/src/org/pentaho/database/service/DatabaseDialectService.java
+++ b/pentaho-database-model/src/org/pentaho/database/service/DatabaseDialectService.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2008-2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2008-2016 Pentaho Corporation.  All rights reserved.
  *
  */
 package org.pentaho.database.service;
@@ -30,12 +30,13 @@ import org.pentaho.database.IDatabaseDialect;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.database.model.IDatabaseType;
 
-public class DatabaseDialectService implements IDatabaseDialectService{
-  
-  private static ServiceLoader<IDatabaseDialect> dialectLoader = ServiceLoader.load(IDatabaseDialect.class);
-  
-  private static final Log logger = LogFactory.getLog(DatabaseDialectService.class);
-  
+public class DatabaseDialectService implements IDatabaseDialectService {
+
+  private static ServiceLoader<IDatabaseDialect> dialectLoader =
+    ServiceLoader.load( IDatabaseDialect.class, DatabaseDialectService.class.getClassLoader() );
+
+  private static final Log logger = LogFactory.getLog( DatabaseDialectService.class );
+
   /*
    * Note - keeping two different list groups for simplicity. The number of valid / provided dialects
    * is low - so it shouldn't balloon memory. If this becomes a single data structure for all
@@ -48,129 +49,138 @@ public class DatabaseDialectService implements IDatabaseDialectService{
    */
   private static final List<IDatabaseDialect> validDatabaseDialects = new ArrayList<IDatabaseDialect>();
   private static final List<IDatabaseType> validDatabaseTypes = new ArrayList<IDatabaseType>();
-  private static final Map<IDatabaseType, IDatabaseDialect> validTypeToDialectMap = new HashMap<IDatabaseType, IDatabaseDialect>();
+  private static final Map<IDatabaseType, IDatabaseDialect> validTypeToDialectMap =
+    new HashMap<IDatabaseType, IDatabaseDialect>();
 
   private static final List<IDatabaseDialect> allDatabaseDialects = new ArrayList<IDatabaseDialect>();
   private static final List<IDatabaseType> allDatabaseTypes = new ArrayList<IDatabaseType>();
-  private static final Map<IDatabaseType, IDatabaseDialect> allTypeToDialectMap = new HashMap<IDatabaseType, IDatabaseDialect>();
+  private static final Map<IDatabaseType, IDatabaseDialect> allTypeToDialectMap =
+    new HashMap<IDatabaseType, IDatabaseDialect>();
 
-  private boolean isOnlyReturnAvailable = true; 
-  
+  private boolean isOnlyReturnAvailable = true;
+
   static {
     DatabaseDialectService.validateAndCatalogServices();
-    if (logger.isDebugEnabled()) {
+    if ( logger.isDebugEnabled() ) {
       logger.debug( "Valid databaseDialects list ..." );
       for ( IDatabaseDialect dialect : validDatabaseDialects ) {
-        logger.debug(String.format( " ... %s ( %s )", dialect.getDatabaseType().getName(), dialect.getDatabaseType().getShortName() ) );
+        logger.debug( String
+          .format( " ... %s ( %s )", dialect.getDatabaseType().getName(), dialect.getDatabaseType().getShortName() ) );
       }
       logger.debug( "All databaseDialects list ..." );
       for ( IDatabaseDialect dialect : allDatabaseDialects ) {
-        logger.debug(String.format( " ... %s ( %s )", dialect.getDatabaseType().getName(), dialect.getDatabaseType().getShortName() ) );
+        logger.debug( String
+          .format( " ... %s ( %s )", dialect.getDatabaseType().getName(), dialect.getDatabaseType().getShortName() ) );
       }
     }
   }
+
   private static void validateAndCatalogServices() {
-    for (IDatabaseDialect dialect : DatabaseDialectService.dialectLoader) {
-      if (logger.isDebugEnabled()) {
-        logger.debug( String.format("Checking for presence of %s ( %s )", dialect.getDatabaseType().getName(), dialect.getNativeDriver() )  );
+    for ( IDatabaseDialect dialect : DatabaseDialectService.dialectLoader ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( String.format( "Checking for presence of %s ( %s )", dialect.getDatabaseType().getName(),
+          dialect.getNativeDriver() ) );
       }
       // Catalog them all
-      DatabaseDialectService.allDatabaseTypes.add(dialect.getDatabaseType());
-      DatabaseDialectService.allTypeToDialectMap.put(dialect.getDatabaseType(), dialect);
-      DatabaseDialectService.allDatabaseDialects.add(dialect);
-      if ( validateJdbcDriverClass(dialect.getNativeDriver())) {
-        DatabaseDialectService.validDatabaseTypes.add(dialect.getDatabaseType());
-        DatabaseDialectService.validTypeToDialectMap.put(dialect.getDatabaseType(), dialect);
-        DatabaseDialectService.validDatabaseDialects.add(dialect);
+      DatabaseDialectService.allDatabaseTypes.add( dialect.getDatabaseType() );
+      DatabaseDialectService.allTypeToDialectMap.put( dialect.getDatabaseType(), dialect );
+      DatabaseDialectService.allDatabaseDialects.add( dialect );
+      if ( validateJdbcDriverClass( dialect.getNativeDriver() ) ) {
+        DatabaseDialectService.validDatabaseTypes.add( dialect.getDatabaseType() );
+        DatabaseDialectService.validTypeToDialectMap.put( dialect.getDatabaseType(), dialect );
+        DatabaseDialectService.validDatabaseDialects.add( dialect );
       } else {
-        if (logger.isDebugEnabled()) {
-          logger.debug( String.format("%s not detected.", dialect.getDatabaseType().getName()) );
+        if ( logger.isDebugEnabled() ) {
+          logger.debug( String.format( "%s not detected.", dialect.getDatabaseType().getName() ) );
         }
-        
+
       }
     }
   }
+
   /**
    * Attempt to load the JDBC Driver class. If it's not available, return false.
-   * 
+   *
    * @param classname validate that this classname exists in the classpath
-   * 
    * @return true if the class exists
    */
-  private static boolean validateJdbcDriverClass(String classname) {
+  private static boolean validateJdbcDriverClass( String classname ) {
     // no need to test if the class exists if it is null
-    if (classname == null) {
+    if ( classname == null ) {
       return true;
     }
-    
+
     try {
-      Class.forName(classname);
+      Class.forName( classname );
       return true;
-    } catch(NoClassDefFoundError e) { 
-      if (logger.isDebugEnabled()) {
-        logger.debug("classExists returning false", e);
+    } catch ( NoClassDefFoundError e ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "classExists returning false", e );
       }
-    } catch(ClassNotFoundException e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("classExists returning false", e);
+    } catch ( ClassNotFoundException e ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "classExists returning false", e );
       }
-    } catch(Exception e) { 
-      if (logger.isDebugEnabled()) {
-        logger.debug("classExists returning false", e);
+    } catch ( Exception e ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "classExists returning false", e );
       }
     }
     // if we've made it here, an exception has occurred.
     return false;
   }
-  
+
   public DatabaseDialectService() {
-    this(true);
+    this( true );
   }
 
-  public DatabaseDialectService(boolean validateClasses) {
+  public DatabaseDialectService( boolean validateClasses ) {
     this.isOnlyReturnAvailable = validateClasses;
-   }
-  
-  public void registerDatabaseDialect(IDatabaseDialect databaseDialect) {
+  }
+
+  public void registerDatabaseDialect( IDatabaseDialect databaseDialect ) {
     // Do nothing here - no need to call this anymore
   }
-  
+
   /**
-   * 
    * @param databaseDialect
    * @param validateClassExists
    */
-  public void registerDatabaseDialect(IDatabaseDialect databaseDialect, boolean validateClassExists) {
+  public void registerDatabaseDialect( IDatabaseDialect databaseDialect, boolean validateClassExists ) {
     // Do nothing here - no need to call this anymore
   }
-  
-  public boolean validateJdbcDriverClassExists(String classname) {
-    return DatabaseDialectService.validateJdbcDriverClass(classname);
+
+  public boolean validateJdbcDriverClassExists( String classname ) {
+    return DatabaseDialectService.validateJdbcDriverClass( classname );
   }
-  
-  
+
+
   public List<IDatabaseType> getDatabaseTypes() {
-    return Collections.unmodifiableList( ( this.isOnlyReturnAvailable ? DatabaseDialectService.validDatabaseTypes:DatabaseDialectService.allDatabaseTypes )  );
+    return Collections.unmodifiableList(
+      ( this.isOnlyReturnAvailable
+        ? DatabaseDialectService.validDatabaseTypes : DatabaseDialectService.allDatabaseTypes ) );
   }
-  
-  public IDatabaseDialect getDialect(IDatabaseType databaseType) {
-    if (this.isOnlyReturnAvailable) {
-      return validTypeToDialectMap.get(databaseType);
+
+  public IDatabaseDialect getDialect( IDatabaseType databaseType ) {
+    if ( this.isOnlyReturnAvailable ) {
+      return validTypeToDialectMap.get( databaseType );
     } else {
-      return allTypeToDialectMap.get(databaseType);
+      return allTypeToDialectMap.get( databaseType );
     }
-    
+
   }
-  
-  public IDatabaseDialect getDialect(IDatabaseConnection connection) {
-    if (this.isOnlyReturnAvailable) {
-      return validTypeToDialectMap.get(connection.getDatabaseType());
+
+  public IDatabaseDialect getDialect( IDatabaseConnection connection ) {
+    if ( this.isOnlyReturnAvailable ) {
+      return validTypeToDialectMap.get( connection.getDatabaseType() );
     } else {
-      return allTypeToDialectMap.get(connection.getDatabaseType());
+      return allTypeToDialectMap.get( connection.getDatabaseType() );
     }
   }
-  
+
   public List<IDatabaseDialect> getDatabaseDialects() {
-    return Collections.unmodifiableList( ( this.isOnlyReturnAvailable ? DatabaseDialectService.validDatabaseDialects:DatabaseDialectService.allDatabaseDialects ) );
+    return Collections.unmodifiableList(
+      ( this.isOnlyReturnAvailable
+        ? DatabaseDialectService.validDatabaseDialects : DatabaseDialectService.allDatabaseDialects ) );
   }
 }


### PR DESCRIPTION
When publishing model from agile-bi we are [creating an instance of DatabaseDialectService](https://github.com/pentaho/pdi-agile-bi-plugin/blob/master/src/org/pentaho/agilebi/spoon/publish/ModelServerPublish.java#L341) class.

But we run into [ServiceConfigurationError](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceConfigurationError.html) wrapped into NoClassDeffoundError because static fields cannot be initialized properly.

It happens because `ServiceLoader#load(Class<S> service)` loads classes with the help of `Thread.currentThread().getContextClassLoader()` classloader.
Thats not what we want here, as DatabaseDialectService and other pentaho-database-model classes are loaded via [Kettels own classloader] (https://github.com/pentaho/pentaho-kettle/blob/master/core/src/org/pentaho/di/core/plugins/KettleURLClassLoader.java), that is a child of thread's content classloader.
So we enforce ServiceLoader to load classes from the same classloader, that DatabaseDialectService class was loaded from.

I also removed Logger, as it is not used anywhere.

Backport of https://github.com/pentaho/pentaho-commons-database/pull/101