### PR TITLE
[BACKLOG-10097] As a new user to Pentaho and creating a connection to…

### DIFF
--- a/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
@@ -1563,7 +1563,7 @@ public class DataHandler extends AbstractXulEventHandler {
       if ( databaseConnection != null && databaseConnection.getDatabaseName() != null && !databaseConnection.getDatabaseName().isEmpty() ) {
         webAppName.setValue( databaseConnection.getDatabaseName() );
       } else {
-        webAppName.setValue( "pentaho-di" );
+        webAppName.setValue( "pentaho" );
       }
     }
   }

--- a/pentaho-database-model/test-src/org/pentaho/database/dialect/PDIDialectTest.java
+++ b/pentaho-database-model/test-src/org/pentaho/database/dialect/PDIDialectTest.java
@@ -48,18 +48,18 @@ public class PDIDialectTest {
   @Before
   public void setUp() {
     when( connection.getAccessType() ).thenReturn( DatabaseAccessType.NATIVE );
-    when( connection.getDatabasePort() ).thenReturn( "9080" );
+    when( connection.getDatabasePort() ).thenReturn( "8080" );
     when( connection.getHostname() ).thenReturn( "localhost" );
   }
 
   @Test
   public void testGetURL() throws Exception {
-    when( connection.getDatabaseName() ).thenReturn( "pentaho-di" );
-    assertThat( dialect.getURL( connection ), equalTo( "jdbc:pdi://localhost:9080/pentaho-di/kettle" ) );
+    when( connection.getDatabaseName() ).thenReturn( "pentaho" );
+    assertThat( dialect.getURL( connection ), equalTo( "jdbc:pdi://localhost:8080/pentaho/kettle" ) );
     Map attributes = new HashMap();
-    attributes.put( "KettleThin.webappname", "pentaho-di" );
+    attributes.put( "KettleThin.webappname", "pentaho" );
     when( connection.getAttributes() ).thenReturn( attributes );
-    assertThat( dialect.getURL( connection ), equalTo( "jdbc:pdi://localhost:9080/pentaho-di/kettle" ) );
+    assertThat( dialect.getURL( connection ), equalTo( "jdbc:pdi://localhost:8080/pentaho/kettle" ) );
   }
 
   @Test


### PR DESCRIPTION
… Pentaho Data Services, I want the default web-app name for the Data Service driver to use 'pentaho' instead of 'pentaho-di' since there is no such web-app in 7.0
@hudak @mkambol 
See also:
https://github.com/pentaho/pdi-dataservice-plugin/pull/75
https://github.com/pentaho/pentaho-kettle/pull/3011