### PR TITLE
[BACKLOG-10097] As a new user to Pentaho and creating a connection to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/
+dist/
+lib/
+test-lib/
+*.iml

--- a/pentaho-database-model/src/org/pentaho/database/dialect/PDIDialect.java
+++ b/pentaho-database-model/src/org/pentaho/database/dialect/PDIDialect.java
@@ -36,7 +36,7 @@ public class PDIDialect extends GenericDatabaseDialect {
   private static final IDatabaseType DBTYPE =
     new DatabaseType( "Pentaho Data Services", "KettleThin",
       DatabaseAccessType.getList( DatabaseAccessType.NATIVE, DatabaseAccessType.JNDI ),
-      9080,
+      8080,
       "https://help.pentaho.com/Documentation/5.1/0L0/0Y0/0G0",
       "Data Services",  // Default database name
       Collections.unmodifiableMap(

--- a/pentaho-database-model/test-src/org/pentaho/database/dialect/PDIDialectTest.java
+++ b/pentaho-database-model/test-src/org/pentaho/database/dialect/PDIDialectTest.java
@@ -29,6 +29,7 @@ import org.pentaho.database.model.DatabaseAccessType;
 import org.pentaho.database.model.DatabaseConnection;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -100,5 +101,10 @@ public class PDIDialectTest {
   @Test
   public void testSupportsOptionsInURL() {
     Assert.assertTrue( dialect.supportsOptionsInURL() );
+  }
+
+  @Test
+  public void testGetDefaultPort() throws Exception {
+    assertEquals( 8080, dialect.getDatabaseType().getDefaultDatabasePort() );
   }
 }


### PR DESCRIPTION
… Pentaho Data Services, I want the default web-app name for the Data Service driver to use 'pentaho' instead of 'pentaho-di' since there is no such web-app in 7.0
@hudak @mkambol 