### PR TITLE
[BACKLOG-10097] As a new user to Pentaho and creating a connection to…

### DIFF
--- a/pentaho-database-model/src/org/pentaho/database/dialect/PDIDialect.java
+++ b/pentaho-database-model/src/org/pentaho/database/dialect/PDIDialect.java
@@ -37,7 +37,7 @@ public class PDIDialect extends GenericDatabaseDialect {
     new DatabaseType( "Pentaho Data Services", "KettleThin",
       DatabaseAccessType.getList( DatabaseAccessType.NATIVE, DatabaseAccessType.JNDI ),
       8080,
-      "https://help.pentaho.com/Documentation/5.1/0L0/0Y0/0G0",
+      "https://help.pentaho.com/Documentation/7.0/0L0/0Y0/0G0",
       "Data Services",  // Default database name
       Collections.unmodifiableMap(
         new HashMap<String, String>() {


### PR DESCRIPTION
… Pentaho Data Services, I want the default web-app name for the Data Service driver to use 'pentaho' instead of 'pentaho-di' since there is no such web-app in 7.0

Merge along with:
https://github.com/pentaho/pdi-dataservice-server-plugin/pull/216
https://github.com/pentaho/pdi-dataservice-plugin/pull/76

@mkambol @hudak 