### PR TITLE
[BACKLOG-8360] PUC-Default value changed from ‘pentaho-di’ to ‘D…

### DIFF
--- a/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
@@ -600,9 +600,8 @@ public class DataHandler extends AbstractXulEventHandler {
         showMessage(
             messages.getString( "DatabaseDialog.ErrorMissingDatabaseName.title" ), //$NON-NLS-1$
             messages.getString( "DatabaseDialog.ErrorMissingDatabaseName.description" ), false ); //$NON-NLS-1$
+        return;
       }
-
-      return;
     }
 
     if ( !checkPoolingParameters() ) {
@@ -1568,7 +1567,8 @@ public class DataHandler extends AbstractXulEventHandler {
     }
 
     if ( webAppName != null ) {
-      if ( databaseConnection != null && databaseConnection.getDatabaseName() != null && !databaseConnection.getDatabaseName().isEmpty() ) {
+
+      if ( databaseConnection != null && databaseConnection.getDatabaseName() != null ) {
         webAppName.setValue( databaseConnection.getDatabaseName() );
       } else {
         webAppName.setValue( "pentaho" );


### PR DESCRIPTION
…ata Services’ after remove the default value from Web App Name and Saved it in PUC

* Fix logic issue with inability to save connection having empty web app name.
+ Once database name is not null (new connection have it null) we know it's existing connection in edit mode, so we just do not reinsert default "pentaho" value for web app name.

@mkambol 