### PR TITLE
[SP-3708][BISERVER-10582]-Database Connection Options List gets cut off when you have more than 5 parameters

### DIFF
--- a/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
+++ b/pentaho-database-gwt/src/org/pentaho/ui/database/event/DataHandler.java
@@ -1631,7 +1631,7 @@ public class DataHandler extends AbstractXulEventHandler {
     maxPoolSizeBox = (XulTextbox) document.getElementById( "max-pool-size-text" ); //$NON-NLS-1$
     poolParameterTree = (XulTree) document.getElementById( "pool-parameter-tree" ); //$NON-NLS-1$
     clusterParameterTree = (XulTree) document.getElementById( "cluster-parameter-tree" ); //$NON-NLS-1$
-    optionsParameterTree = (XulTree) document.getElementById( "options-parameter-tree" ); //$NON-NLS-1$
+    optionsParameterTree = (XulTree) document.getElementById( "puc_options-parameter-tree" ); //$NON-NLS-1$
     poolingDescription = (XulTextbox) document.getElementById( "pooling-description" ); //$NON-NLS-1$ 
     poolingParameterDescriptionLabel =
         (XulLabel) document.getElementById( "pool-parameter-description-label" ); //$NON-NLS-1$

--- a/pentaho-database-gwt/src/org/pentaho/ui/database/resources/databasedialog.xul
+++ b/pentaho-database-gwt/src/org/pentaho/ui/database/resources/databasedialog.xul
@@ -119,7 +119,7 @@
                      Tested and couldn't find any problems with having 100% width.
                      -->
 				
-				<tree id="options-parameter-tree" flex="1" width="100%" editable="true" onedit="dataHandler.editOptions()" seltype="cell">
+				<tree id="puc_options-parameter-tree" flex="1" width="100%" editable="true" onedit="dataHandler.editOptions()" seltype="cell">
 
 					<treecols id="option-column-list">
 					  	<treecol id="parameter-col" label="${DatabaseDialog.column.Parameter}" flex="1" editable="true" type="text"/>  


### PR DESCRIPTION
 - rename id from options-parameter-tree to puc_options-parameter-tree
 due to #options-parameter-tree .gwt-ScrollTable  from
 datasourceEditorDialog.css which override height parameter