### PR TITLE
[BACKLOG-29979] - setting jdbc options separator for snowflake dialect

### DIFF
--- a/model/src/main/java/org/pentaho/database/dialect/SnowflakeDatabaseDialect.java
+++ b/model/src/main/java/org/pentaho/database/dialect/SnowflakeDatabaseDialect.java
@@ -40,21 +40,25 @@ public class SnowflakeDatabaseDialect extends AbstractDatabaseDialect {
     }
   }
 
+  @Override public String getExtraOptionSeparator() {
+    return "&";
+  }
+
   @Override
-  public String getAddColumnStatement( String tablename, IValueMeta v, String tk, boolean use_autoinc, String pk,
+  public String getAddColumnStatement( String tablename, IValueMeta v, String tk, boolean useAutoinc, String pk,
                                        boolean semicolon ) {
     return null;
   }
 
   @Override
-  public String getModifyColumnStatement( String tablename, IValueMeta v, String tk, boolean use_autoinc, String pk,
+  public String getModifyColumnStatement( String tablename, IValueMeta v, String tk, boolean useAutoinc, String pk,
                                           boolean semicolon ) {
     return null;
   }
 
   @Override
-  public String getFieldDefinition( IValueMeta v, String tk, String pk, boolean use_autoinc, boolean add_fieldname,
-                                    boolean add_cr ) {
+  public String getFieldDefinition( IValueMeta v, String tk, String pk, boolean useAutoinc, boolean addFieldname,
+                                    boolean addCr ) {
     return null;
   }
 

--- a/model/src/test/java/org/pentaho/database/dialect/SnowflakeDatabaseDialectTest.java
+++ b/model/src/test/java/org/pentaho/database/dialect/SnowflakeDatabaseDialectTest.java
@@ -1,0 +1,39 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2019 Hitachi Vantara..  All rights reserved.
+ */
+package org.pentaho.database.dialect;
+
+import org.junit.Test;
+import org.pentaho.database.DatabaseDialectException;
+import org.pentaho.database.model.DatabaseConnection;
+import org.pentaho.database.model.IDatabaseConnection;
+
+import static org.junit.Assert.assertEquals;
+
+public class SnowflakeDatabaseDialectTest {
+  @Test
+  public void databaseOptionsUsesCorrectSeparator() throws DatabaseDialectException {
+    SnowflakeDatabaseDialect dialect = new SnowflakeDatabaseDialect();
+    IDatabaseConnection conn = new DatabaseConnection();
+    conn.setDatabaseType( SnowflakeDatabaseDialect.DBTYPE );
+    conn.setHostname( "abc.snowflake.com" );
+    conn.setDatabasePort( "123" );
+    conn.setDatabaseName( "words" );
+    conn.addExtraOption( SnowflakeDatabaseDialect.DBTYPE.getShortName(), "CLIENT_SESSION_KEEP_ALIVE", "true" );
+    assertEquals( "jdbc:snowflake://abc.snowflake.com:123/?db=words&warehouse=null&CLIENT_SESSION_KEEP_ALIVE=true",
+      dialect.getURLWithExtraOptions( conn ) );
+  }
+}


### PR DESCRIPTION
correct small sonar complaints