### PR TITLE
Revert "Merge pull request #178 from gryphendowre/SP-5370"

### DIFF
--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -17,6 +17,7 @@
     <commons-xul.version>9.0.0.0-SNAPSHOT</commons-xul.version>
     <commons-gwt.version>9.0.0.0-SNAPSHOT</commons-gwt.version>
     <pdi.version>9.0.0.0-SNAPSHOT</pdi.version>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
   </properties>
 
   <dependencies>
@@ -230,11 +231,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <version>${commons-vfs2.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -13,6 +13,10 @@
     <version>9.0.0.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <commons-vfs2.version>2.2</commons-vfs2.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.pentaho</groupId>
@@ -29,6 +33,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
+      <version>${commons-vfs2.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
This reverts commit c9ba6ccba4f595876bae3c0961f883cc4729a2fd, reversing
changes made to 002edf679ac3858c12a23a5d545072f1173932a0.

This Revert PR is part of a series:
- https://github.com/pentaho/maven-parent-poms/pull/229
- https://github.com/pentaho/apache-vfs-browser/pull/62
- https://github.com/pentaho/big-data-plugin/pull/2040
- https://github.com/webdetails/cpk/pull/87
- https://github.com/pentaho/data-access/pull/1091
- https://github.com/pentaho/mondrian/pull/1202
- https://github.com/pentaho/pdi-jms-plugin/pull/76
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/104
- https://github.com/pentaho/pdi-plugins-ee/pull/174
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/84
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/53
- https://github.com/pentaho/pentaho-big-data-ee/pull/444
- https://github.com/pentaho/pentaho-commons-database/pull/179
- https://github.com/pentaho/pentaho-data-mining/pull/26
- https://github.com/pentaho/pentaho-det-ee/pull/616
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/23
- https://github.com/pentaho/pentaho-karaf-assembly/pull/635
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/290
- https://github.com/pentaho/pentaho-kettle/pull/7334
- https://github.com/pentaho/pentaho-metaverse/pull/621
- https://github.com/pentaho/pentaho-osgi-bundles/pull/363
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1504
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/341
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/790
- https://github.com/pentaho/pentaho-platform/pull/4658
- https://github.com/pentaho/pentaho-reporting/pull/1342
- https://github.com/pentaho/pentaho-s3-vfs/pull/94
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/17