### PR TITLE
[BACKLOG-38287] [Database Connection] -- The parameters section for pooling tab are not visible

### DIFF
--- a/gwt/src/main/resources/org/pentaho/ui/database/resources/databasedialog.xul
+++ b/gwt/src/main/resources/org/pentaho/ui/database/resources/databasedialog.xul
@@ -174,7 +174,7 @@
 
 					<tree id="pool-parameter-tree" flex="3" rows="5" editable="false" seltype="single" disabled="true" onselect="dataHandler.poolingRowChange()">
 						<treecols id="column-list">
-						  	<treecol id="select-col"  fixed="true" type="checkbox" flex="1" editable="true" />  
+						  	<treecol id="select-col"  fixed="true" type="checkbox" flex="3" editable="true" />  
 							<treecol id="parameter-col" fixed="true" label="${DatabaseDialog.column.PoolParameter}" flex="7" editable="false" />
 							<treecol id="value-col" fixed="true" label="${DatabaseDialog.column.PoolValue}" flex="7" pen:customeditor="variabletextbox" editable="true" type="text" />
 						</treecols>


### PR DESCRIPTION
@pentaho/wcag , Please review
This PR is part of https://github.com/pentaho/data-access/pull/1220