### PR TITLE
[BISERVER-15027] MySQL8 database repository for pentaho server does not work properly with mysql8 jar

### DIFF
--- a/model/src/main/java/org/pentaho/database/dialect/MySQLDatabaseDialect.java
+++ b/model/src/main/java/org/pentaho/database/dialect/MySQLDatabaseDialect.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.database.dialect;
@@ -43,7 +43,13 @@ public class MySQLDatabaseDialect extends AbstractDatabaseDialect {
   }
 
   public String getNativeDriver() {
-    return "org.gjt.mm.mysql.Driver";
+    String driver = "com.mysql.cj.jdbc.Driver";
+    try {
+      Class.forName( driver );
+    } catch ( ClassNotFoundException e ) {
+      driver = "org.gjt.mm.mysql.Driver";
+    }
+    return driver;
   }
 
   /**


### PR DESCRIPTION
[BISERVER-15027] MySQL8 database repository for pentaho server does not work properly with mysql8 jar

[BISERVER-15027]: https://hv-eng.atlassian.net/browse/BISERVER-15027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ