### PR TITLE
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

### DIFF
--- a/model/src/main/java/org/pentaho/database/dialect/MySQLDatabaseDialect.java
+++ b/model/src/main/java/org/pentaho/database/dialect/MySQLDatabaseDialect.java
@@ -48,7 +48,7 @@ public class MySQLDatabaseDialect extends AbstractDatabaseDialect {
     try {
       Class.forName( driver );
     } catch ( ClassNotFoundException e ) {
-      driver = "org.gjt.mm.mysql.Driver";
+      driver = "com.mysql.jdbc.Driver";
     }
     return driver;
   }


### PR DESCRIPTION
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

[BACKLOG-40978]: https://hv-eng.atlassian.net/browse/BACKLOG-40978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ