### PR TITLE
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

### DIFF
--- a/gwt/src/it/java/org/pentaho/database/service/DatabaseConnectionServiceIT.java
+++ b/gwt/src/it/java/org/pentaho/database/service/DatabaseConnectionServiceIT.java
@@ -71,7 +71,7 @@ public class DatabaseConnectionServiceIT {
     DatabaseTypeHelper helper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
 
     IDatabaseConnection conn = connectionService.createDatabaseConnection(
-        "org.gjt.mm.mysql.Driver", "jdbc:mysql://localhost:1234/testdb" );
+        "com.mysql.jdbc.Driver", "jdbc:mysql://localhost:1234/testdb" );
 
     Assert.assertNotNull( conn );
     Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
@@ -81,7 +81,7 @@ public class DatabaseConnectionServiceIT {
     Assert.assertEquals( "testdb", conn.getDatabaseName() );
 
     conn = connectionService.createDatabaseConnection(
-        "org.gjt.mm.mysql.Driver", "jdbc:mysql://localhost/testdb" );
+        "com.mysql.jdbc.Driver", "jdbc:mysql://localhost/testdb" );
 
     Assert.assertNotNull( conn );
     Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );

--- a/model/src/main/java/org/pentaho/database/dialect/MySQLDatabaseDialect.java
+++ b/model/src/main/java/org/pentaho/database/dialect/MySQLDatabaseDialect.java
@@ -48,7 +48,7 @@ public class MySQLDatabaseDialect extends AbstractDatabaseDialect {
     try {
       Class.forName( driver );
     } catch ( ClassNotFoundException e ) {
-      driver = "org.gjt.mm.mysql.Driver";
+      driver = "com.mysql.jdbc.Driver";
     }
     return driver;
   }

--- a/model/src/test/java/org/pentaho/database/dialect/MySQLDatabaseDialectTest.java
+++ b/model/src/test/java/org/pentaho/database/dialect/MySQLDatabaseDialectTest.java
@@ -36,7 +36,7 @@ public class MySQLDatabaseDialectTest {
 
   @Test
   public void testGetNativeDriver() {
-    assertEquals( dialect.getNativeDriver(), "org.gjt.mm.mysql.Driver" );
+    assertEquals( dialect.getNativeDriver(), "com.mysql.jdbc.Driver" );
   }
 
   @Test


### PR DESCRIPTION
[BACKLOG-40978] 10.2: Default driver class used is org.gjt.mm.mysql.driver instead of recommended com.mysql.jdbc.Driver

[BACKLOG-40978]: https://hv-eng.atlassian.net/browse/BACKLOG-40978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ