### PR TITLE
fix: fix gwt module dependencies and ITs

### DIFF
--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -17,7 +17,6 @@
     <commons-xul.version>10.3.0.0-SNAPSHOT</commons-xul.version>
     <commons-gwt.version>10.3.0.0-SNAPSHOT</commons-gwt.version>
     <pdi.version>10.3.0.0-SNAPSHOT</pdi.version>
-    <encryption-support.version>10.3.0.0-SNAPSHOT</encryption-support.version>
   </properties>
 
   <dependencies>
@@ -26,12 +25,6 @@
       <groupId>org.pentaho</groupId>
       <artifactId>commons-database-model</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- pentaho dependencies -->
@@ -39,40 +32,11 @@
       <groupId>org.pentaho</groupId>
       <artifactId>commons-gwt-widgets</artifactId>
       <version>${commons-gwt.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-core</artifactId>
       <version>${pdi.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-encryption-support</artifactId>
-      <version>${encryption-support.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho-kettle</groupId>
-      <artifactId>kettle-engine</artifactId>
-      <version>${pdi.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
@@ -81,138 +45,25 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
-      <artifactId>commons-xul-swing</artifactId>
-      <version>${commons-xul.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho</groupId>
       <artifactId>commons-xul-swt</artifactId>
       <version>${commons-xul.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>commons-xul-gwt-impl</artifactId>
       <version>${commons-xul.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- third party dependencies -->
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-pool2</artifactId>
-      <version>${commons-pool2.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-dbcp2</artifactId>
-      <version>${commons-dbcp2.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse</groupId>
-      <artifactId>jface</artifactId>
-      <version>3.3.0-I20070606-0010</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.core</groupId>
-      <artifactId>runtime</artifactId>
-      <version>3.3.100-v20070530</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.equinox</groupId>
-      <artifactId>common</artifactId>
-      <version>3.3.0-v20070426</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.core</groupId>
-      <artifactId>commands</artifactId>
-      <version>3.3.0-I20070605-0010</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
     <dependency>
       <groupId>org.eclipse.swt</groupId>
       <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
@@ -228,53 +79,29 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>metastore</artifactId>
-      <version>${pdi.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-dev</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>5.10.0</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- IT dependencies -->
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-vfs2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>pentaho-kettle</groupId>
+      <artifactId>kettle-engine</artifactId>
+      <version>${pdi.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.10</version>
+      <version>5.1.49</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.2</version>
+      <version>2.7.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -93,10 +93,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.49</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.4.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Exclude the transitive dependency on protobuf-java due to CVE-2024-7254,
+               This exclusion may be removed in a future upgrade, when safe.-->
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hsqldb</groupId>

--- a/gwt/src/it/java/org/pentaho/database/service/DatabaseConnectionServiceIT.java
+++ b/gwt/src/it/java/org/pentaho/database/service/DatabaseConnectionServiceIT.java
@@ -13,7 +13,7 @@
 
 package org.pentaho.database.service;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.database.DatabaseDialectException;
 import org.pentaho.database.dialect.GenericDatabaseDialect;
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 public class DatabaseConnectionServiceIT {
 
   public static final String DRIVER_ORG_MYSQL = "org.mysql.Driver";
-  public static final String DRIVER_MYSQL_JDBC = "com.mysql.jdbc.Driver";
+  public static final String DRIVER_MYSQL_JDBC = "com.mysql.cj.jdbc.Driver";
   public static final String DRIVER_MICROSOFT_SQLSERVER = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
   public static final String DRIVER_HSQLDB = "org.hsqldb.jdbcDriver";
 
@@ -44,12 +44,12 @@ public class DatabaseConnectionServiceIT {
   public static final String TEST_DB_NAME = "testdb";
   public static final String DATABASE_SHORTNAME_GENERIC = "GENERIC";
 
-  DatabaseDialectService dialectService;
-  DatabaseConnectionService connectionService;
-  DatabaseTypeHelper helper;
+  static DatabaseDialectService dialectService;
+  static DatabaseConnectionService connectionService;
+  static DatabaseTypeHelper helper;
 
-  @Before
-  public void setUp() {
+  @BeforeClass
+  public static void setUp() {
     dialectService = new DatabaseDialectService( false );
     connectionService = new DatabaseConnectionService( dialectService );
     helper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );

--- a/gwt/src/it/java/org/pentaho/database/service/DatabaseConnectionServiceIT.java
+++ b/gwt/src/it/java/org/pentaho/database/service/DatabaseConnectionServiceIT.java
@@ -13,293 +13,297 @@
 
 package org.pentaho.database.service;
 
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.database.DatabaseDialectException;
 import org.pentaho.database.dialect.GenericDatabaseDialect;
 import org.pentaho.database.dialect.MSSQLServerNativeDatabaseDialect;
 import org.pentaho.database.model.DatabaseAccessType;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.database.util.DatabaseTypeHelper;
-import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.database.DatabaseMeta;
 
-@SuppressWarnings( "nls" )
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 public class DatabaseConnectionServiceIT {
 
-  @Test
-  public void testMSSQL() throws Exception {
-    KettleEnvironment.init( false );
-    DatabaseMeta dbmeta = new DatabaseMeta();
-    dbmeta.setDatabaseType( "MSSQL" );
-    dbmeta.setHostname( "localhost" );
-    dbmeta.setDBName( "test" );
-    System.out.println( dbmeta.getURL() );
-    dbmeta.setServername( "test" ); //(true);
+  public static final String DRIVER_ORG_MYSQL = "org.mysql.Driver";
+  public static final String DRIVER_MYSQL_JDBC = "com.mysql.jdbc.Driver";
+  public static final String DRIVER_MICROSOFT_SQLSERVER = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+  public static final String DRIVER_HSQLDB = "org.hsqldb.jdbcDriver";
+
+  public static final String DB_TYPE_GENERIC = "Generic database";
+  public static final String DB_TYPE_MYSQL = "MySQL";
+  public static final String DB_TYPE_MS_SQL = "MS SQL Server (Native)";
+  public static final String DB_TYPE_HYPERSONIC = "Hypersonic";
+
+  public static final String TEST_HOST = "localhost";
+  public static final String TEST_PORT = "1234";
+  public static final String TEST_DB_NAME = "testdb";
+  public static final String DATABASE_SHORTNAME_GENERIC = "GENERIC";
+
+  DatabaseDialectService dialectService;
+  DatabaseConnectionService connectionService;
+  DatabaseTypeHelper helper;
+
+  @Before
+  public void setUp() {
+    dialectService = new DatabaseDialectService( false );
+    connectionService = new DatabaseConnectionService( dialectService );
+    helper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
   }
 
   @Test
-  public void testCreateGenericConnection() throws Exception {
-    DatabaseDialectService dialectService = new DatabaseDialectService();
-    DatabaseConnectionService connectionService = new DatabaseConnectionService();
-    DatabaseTypeHelper helper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
-
+  public void testCreateGenericDatabaseConnection() throws Exception {
     IDatabaseConnection conn = connectionService.createDatabaseConnection(
-        "org.mysql.Driver", "jdbc:mysql://localhost:1234/testdb" );
+      DRIVER_ORG_MYSQL, "jdbc:mysql://localhost:1234/testdb" );
 
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByShortName( "GENERIC" ), conn.getDatabaseType() );
-    Assert.assertEquals( "org.mysql.Driver",
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByShortName( DATABASE_SHORTNAME_GENERIC ), conn.getDatabaseType() );
+    assertEquals( DRIVER_ORG_MYSQL,
         conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS ) );
-    Assert.assertEquals( "jdbc:mysql://localhost:1234/testdb",
+    assertEquals( "jdbc:mysql://localhost:1234/testdb",
         conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_URL ) );
 
     conn.addExtraOption( conn.getDatabaseType().getShortName(), "test", "true" );
 
     String urlString = dialectService.getDialect( conn ).getURLWithExtraOptions( conn );
-    Assert.assertEquals( "jdbc:mysql://localhost:1234/testdb", urlString );
+    assertEquals( "jdbc:mysql://localhost:1234/testdb", urlString );
   }
 
   @Test
-  public void testCreateMySQLDatabaseConnection() throws Exception {
-    DatabaseDialectService dialectService = new DatabaseDialectService();
-    DatabaseConnectionService connectionService = new DatabaseConnectionService();
-    DatabaseTypeHelper helper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
-
+  public void testCreateMySQLDatabaseConnection_withPort() {
     IDatabaseConnection conn = connectionService.createDatabaseConnection(
-        "com.mysql.jdbc.Driver", "jdbc:mysql://localhost:1234/testdb" );
+      DRIVER_MYSQL_JDBC, "jdbc:mysql://localhost:1234/testdb" );
 
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MySQL" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( "1234", conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "com.mysql.jdbc.Driver", "jdbc:mysql://localhost/testdb" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MySQL" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.gjt.mm.mysql.Driver", "jdbc:mysql://testdb" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MySQL" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.gjt.mm.mysql.Driver", "jasddbc:mysql://testdb" );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Generic database" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( null, conn.getDatabaseName() );
-    Assert.assertEquals( null, conn.getDatabaseName() );
-    Assert.assertEquals( "jasddbc:mysql://testdb",
-        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_URL ) );
-    Assert.assertEquals( "org.gjt.mm.mysql.Driver",
-        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS ) );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.gjt.mm.mysql.Driver", "jdbc:mysql://localhost:1234/testdb?autoCommit=true&test=FALSE" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MySQL" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( "1234", conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-    Assert.assertEquals( 2, conn.getExtraOptions().size() );
-    Assert.assertEquals( "true", conn.getExtraOptions().get( "MYSQL.autoCommit" ) );
-    Assert.assertEquals( "FALSE", conn.getExtraOptions().get( "MYSQL.test" ) );
-
-    String urlString = dialectService.getDialect( conn ).getURLWithExtraOptions( conn );
-    Assert.assertEquals( "jdbc:mysql://localhost:1234/testdb?test=FALSE&autoCommit=true", urlString );
-
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_MYSQL ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertEquals( TEST_PORT, conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
   }
 
   @Test
-  public void testCreateMSSQLNativeDatabaseConnection() throws Exception {
-    DatabaseDialectService dialectService = new DatabaseDialectService( false );
-    DatabaseConnectionService connectionService = new DatabaseConnectionService( dialectService );
-    DatabaseTypeHelper helper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
-
+  public void testCreateMySQLDatabaseConnection_withoutPort() {
     IDatabaseConnection conn = connectionService.createDatabaseConnection(
-        "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-        "jdbc:sqlserver://localhost:1234;databaseName=testdb;integratedSecurity=false" );
+      DRIVER_MYSQL_JDBC, "jdbc:mysql://localhost/testdb" );
 
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MS SQL Server (Native)" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( "1234", conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-    Assert.assertEquals( "false",
-        conn.getAttributes().get( MSSQLServerNativeDatabaseDialect.ATTRIBUTE_USE_INTEGRATED_SECURITY ) );
-
-    conn = connectionService.createDatabaseConnection(
-        "com.microsoft.sqlserver.jdbc.SQLServerDriver", "jdbc:sqlserver://localhost;databaseName=testdb" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MS SQL Server (Native)" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "com.microsoft.sqlserver.jdbc.SQLServerDriver", "jdbc:sqlserver://testdb" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MS SQL Server (Native)" ), conn.getDatabaseType() );
-    Assert.assertEquals( "testdb", conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( null, conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "com.microsoft.sqlserver.jdbc.SQLServerDriver", "jasddbc:mysql://testdb" );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Generic database" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( null, conn.getDatabaseName() );
-    Assert.assertEquals( null, conn.getDatabaseName() );
-    Assert.assertEquals( "jasddbc:mysql://testdb",
-        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_URL ) );
-    Assert.assertEquals( "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS ) );
-
-    conn = connectionService.createDatabaseConnection(
-        "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-        "jdbc:sqlserver://localhost:1234;databaseName=testdb;autoCommit=true;test=FALSE" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "MS SQL Server (Native)" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( "1234", conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-    Assert.assertEquals( 2, conn.getExtraOptions().size() );
-    Assert.assertEquals( "true", conn.getExtraOptions().get( "MSSQLNative.autoCommit" ) );
-    Assert.assertEquals( "FALSE", conn.getExtraOptions().get( "MSSQLNative.test" ) );
-
-    String urlString = dialectService.getDialect( conn ).getURLWithExtraOptions( conn );
-    Assert.assertEquals(
-        "jdbc:sqlserver://localhost:1234;databaseName=testdb;integratedSecurity=false;test=FALSE;autoCommit=true",
-        urlString );
-
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_MYSQL ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
   }
 
   @Test
-  public void testCreateHypersonicDatabaseConnection() throws Exception {
-    DatabaseDialectService dialectService = new DatabaseDialectService();
-    DatabaseConnectionService connectionService = new DatabaseConnectionService();
-    DatabaseTypeHelper helper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
-
+  public void testCreateMySQLDatabaseConnection_withExtraOptions() throws DatabaseDialectException {
     IDatabaseConnection conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://localhost:1234/testdb" );
+      DRIVER_MYSQL_JDBC, "jdbc:mysql://localhost:1234/testdb?autoCommit=true&test=FALSE" );
 
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Hypersonic" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( "1234", conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://localhost/testdb" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Hypersonic" ), conn.getDatabaseType() );
-    Assert.assertEquals( "localhost", conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://testdb" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Hypersonic" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqldb:file:testdb" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Hypersonic" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "file:testdb", conn.getDatabaseName() );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqasdldb:testdb" );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Generic database" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( null, conn.getDatabaseName() );
-    Assert.assertEquals( null, conn.getDatabaseName() );
-    Assert.assertEquals( "jdbc:hsqasdldb:testdb",
-        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_URL ) );
-    Assert.assertEquals( "org.hsqldb.jdbcDriver",
-        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS ) );
-
-    // test URL parameters
-    conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://testdb;ifexists=true;test=false" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Hypersonic" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-    Assert.assertEquals( 2, conn.getExtraOptions().size() );
-    Assert.assertEquals( "true", conn.getExtraOptions().get( "HYPERSONIC.ifexists" ) );
-    Assert.assertEquals( "false", conn.getExtraOptions().get( "HYPERSONIC.test" ) );
-
-    conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://testdb;ifexists=true;test=false;" );
-
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Hypersonic" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-    Assert.assertEquals( 2, conn.getExtraOptions().size() );
-    Assert.assertEquals( "true", conn.getExtraOptions().get( "HYPERSONIC.ifexists" ) );
-    Assert.assertEquals( "false", conn.getExtraOptions().get( "HYPERSONIC.test" ) );
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_MYSQL ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertEquals( TEST_PORT, conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+    assertEquals( 2, conn.getExtraOptions().size() );
+    assertEquals( "true", conn.getExtraOptions().get( "MYSQL.autoCommit" ) );
+    assertEquals( "FALSE", conn.getExtraOptions().get( "MYSQL.test" ) );
 
     String urlString = dialectService.getDialect( conn ).getURLWithExtraOptions( conn );
-    Assert.assertEquals( "jdbc:hsqldb:testdb;ifexists=true;test=false", urlString );
+    assertTrue( urlString.startsWith( "jdbc:mysql://localhost:1234/testdb?" ) );
+    assertTrue( urlString.contains( "test=FALSE" ) );
+    assertTrue( urlString.contains( "autoCommit=true" ) );
+  }
 
-    conn = connectionService.createDatabaseConnection(
-        "org.hsqldb.jdbcDriver", "jdbc:hsqldb:hsql://testdb;" );
+  @Test
+  public void testCreateMSSQLNativeDatabaseConnection_withPort() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_MICROSOFT_SQLSERVER,
+      "jdbc:sqlserver://localhost:1234;databaseName=testdb;integratedSecurity=false" );
 
-    Assert.assertNotNull( conn );
-    Assert.assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
-    Assert.assertEquals( helper.getDatabaseTypeByName( "Hypersonic" ), conn.getDatabaseType() );
-    Assert.assertEquals( null, conn.getHostname() );
-    Assert.assertEquals( null, conn.getDatabasePort() );
-    Assert.assertEquals( "testdb", conn.getDatabaseName() );
-    Assert.assertEquals( 0, conn.getExtraOptions().size() );
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_MS_SQL ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertEquals( TEST_PORT, conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+    assertEquals( "false",
+      conn.getAttributes().get( MSSQLServerNativeDatabaseDialect.ATTRIBUTE_USE_INTEGRATED_SECURITY ) );
+  }
 
+  @Test
+  public void testCreateMSSQLNativeDatabaseConnection_withoutPort() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_MICROSOFT_SQLSERVER, "jdbc:sqlserver://localhost;databaseName=testdb" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_MS_SQL ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+  }
+
+  @Test
+  public void testCreateMSSQLNativeDatabaseConnection_noDatabaseName() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_MICROSOFT_SQLSERVER, "jdbc:sqlserver://testdb" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_MS_SQL ), conn.getDatabaseType() );
+    assertEquals( TEST_DB_NAME, conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertNull( conn.getDatabaseName() );
+  }
+
+  @Test
+  public void testCreateMSSQLNativeDatabaseConnection_genericDatabase() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_MICROSOFT_SQLSERVER, "jasddbc:mysql://testdb" );
+
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_GENERIC ), conn.getDatabaseType() );
+    assertNull( conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertNull( conn.getDatabaseName() );
+    assertNull( conn.getDatabaseName() );
+    assertEquals( "jasddbc:mysql://testdb",
+      conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_URL ) );
+    assertEquals( DRIVER_MICROSOFT_SQLSERVER,
+      conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS ) );
+  }
+
+  @Test
+  public void testCreateMSSQLNativeDatabaseConnection_withExtraOptions() throws DatabaseDialectException {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_MICROSOFT_SQLSERVER,
+      "jdbc:sqlserver://localhost:1234;databaseName=testdb;autoCommit=true;test=FALSE" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_MS_SQL ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertEquals( TEST_PORT, conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+    assertEquals( 2, conn.getExtraOptions().size() );
+    assertEquals( "true", conn.getExtraOptions().get( "MSSQLNative.autoCommit" ) );
+    assertEquals( "FALSE", conn.getExtraOptions().get( "MSSQLNative.test" ) );
+
+    String urlString = dialectService.getDialect( conn ).getURLWithExtraOptions( conn );
+    assertTrue( urlString.startsWith( "jdbc:sqlserver://localhost:1234;databaseName=testdb;integratedSecurity=false;" ) );
+    assertTrue( urlString.contains( "test=FALSE" ) );
+    assertTrue( urlString.contains( "autoCommit=true" ) );
+  }
+
+  @Test
+  public void testCreateHypersonicDatabaseConnection_withPort() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_HSQLDB, "jdbc:hsqldb:hsql://localhost:1234/testdb" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_HYPERSONIC ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertEquals( TEST_PORT, conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+  }
+
+  @Test
+  public void testCreateHypersonicDatabaseConnection_withoutPort() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_HSQLDB, "jdbc:hsqldb:hsql://localhost/testdb" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_HYPERSONIC ), conn.getDatabaseType() );
+    assertEquals( TEST_HOST, conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+  }
+
+  @Test
+  public void testCreateHypersonicDatabaseConnection_withoutHost() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_HSQLDB, "jdbc:hsqldb:hsql://testdb" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_HYPERSONIC ), conn.getDatabaseType() );
+    assertNull( conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+  }
+
+  @Test
+  public void testCreateHypersonicDatabaseConnection_withFile() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_HSQLDB, "jdbc:hsqldb:file:testdb" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_HYPERSONIC ), conn.getDatabaseType() );
+    assertNull( conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertEquals( "file:testdb", conn.getDatabaseName() );
+  }
+
+  @Test
+  public void testCreateHypersonicDatabaseConnection_genericDatabase() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_HSQLDB, "jdbc:hsqasdldb:testdb" );
+
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_GENERIC ), conn.getDatabaseType() );
+    assertNull( conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertNull( conn.getDatabaseName() );
+    assertNull( conn.getDatabaseName() );
+    assertEquals( "jdbc:hsqasdldb:testdb",
+        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_URL ) );
+    assertEquals( DRIVER_HSQLDB,
+        conn.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS ) );
+  }
+
+  @Test
+  public void testCreateHypersonicDatabaseConnection_withExtraOptions() throws DatabaseDialectException {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_HSQLDB, "jdbc:hsqldb:hsql://testdb;ifexists=true;test=false;" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_HYPERSONIC ), conn.getDatabaseType() );
+    assertNull( conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+    assertEquals( 2, conn.getExtraOptions().size() );
+    assertEquals( "true", conn.getExtraOptions().get( "HYPERSONIC.ifexists" ) );
+    assertEquals( "false", conn.getExtraOptions().get( "HYPERSONIC.test" ) );
+
+    String urlString = dialectService.getDialect( conn ).getURLWithExtraOptions( conn );
+    assertTrue( urlString.startsWith( "jdbc:hsqldb:testdb;" ) );
+    assertTrue( urlString.contains( ";ifexists=true" ) );
+    assertTrue( urlString.contains( ";test=false" ) );
+  }
+
+  @Test
+  public void testCreateHypersonicDatabaseConnection_noExtraOptions() {
+    IDatabaseConnection conn = connectionService.createDatabaseConnection(
+      DRIVER_HSQLDB, "jdbc:hsqldb:hsql://testdb;" );
+
+    assertNotNull( conn );
+    assertEquals( DatabaseAccessType.NATIVE, conn.getAccessType() );
+    assertEquals( helper.getDatabaseTypeByName( DB_TYPE_HYPERSONIC ), conn.getDatabaseType() );
+    assertNull( conn.getHostname() );
+    assertNull( conn.getDatabasePort() );
+    assertEquals( TEST_DB_NAME, conn.getDatabaseName() );
+    assertTrue( conn.getExtraOptions().isEmpty() );
   }
 
 }


### PR DESCRIPTION
Goal
--
The goal of this PR is to fix the currently failing ITs in the `gwt` module. The ITs file, `DatabaseConnectionServiceIT` was also refactored to split each test case into a different test method, among other improvements. All Sonar issues in the file were also tackled.

Since some failing ITs were due to dependency issues, significant changes to the `gwt/pom.xml` file were also included. Focusing on dependency management and cleanup. The main changes involve the removal of several dependencies and exclusions, as well as updates to some dependency versions.

Dependency management and cleanup:
--
* Removed the `encryption-support.version` property from the `<properties>` section.
* Removed multiple dependencies and their exclusions, including `pentaho-encryption-support`, `commons-pool2`, `commons-dbcp2`, `commons-beanutils`, and several `org.eclipse` dependencies.
* Updated the `gwt-user` dependency to use the `org.gwtproject` group and version `2.10.0`.
* Removed several test dependencies, including `pentaho-metastore`, `gwt-dev`, `commons-vfs2`, `httpclient`, `guava`, and `slf4j-api`. Added `kettle-engine` as an integration test dependency.
* Updated the versions of `mysql-connector-java` to `5.1.49` and `hsqldb` to `2.7.4` for test scope.

Tests
--
After these changes, **all UTs and ITs passed in a local setup**. **The module was also tested in a running `pentaho-server`**.

Please review @pentaho/tatooine_dev 