### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseConnectionList.java
+++ b/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseConnectionList.java
@@ -15,8 +15,8 @@ package org.pentaho.ui.database.event;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;

--- a/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseConnectionPoolParameterList.java
+++ b/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseConnectionPoolParameterList.java
@@ -15,8 +15,8 @@ package org.pentaho.ui.database.event;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.pentaho.database.model.DatabaseConnectionPoolParameter;
 import org.pentaho.database.model.IDatabaseConnectionPoolParameter;

--- a/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseDialectList.java
+++ b/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseDialectList.java
@@ -15,8 +15,8 @@ package org.pentaho.ui.database.event;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAnyElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAnyElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.pentaho.database.IDatabaseDialect;
 

--- a/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseTypesList.java
+++ b/gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseTypesList.java
@@ -15,8 +15,8 @@ package org.pentaho.ui.database.event;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.pentaho.database.model.DatabaseType;
 import org.pentaho.database.model.IDatabaseType;

--- a/model/src/main/java/org/pentaho/database/model/DatabaseConnection.java
+++ b/model/src/main/java/org/pentaho/database/model/DatabaseConnection.java
@@ -23,8 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class DatabaseConnection implements Serializable, IDatabaseConnection {

--- a/model/src/main/java/org/pentaho/database/model/DatabaseConnectionPoolParameter.java
+++ b/model/src/main/java/org/pentaho/database/model/DatabaseConnectionPoolParameter.java
@@ -15,7 +15,7 @@ package org.pentaho.database.model;
 
 import java.io.Serializable;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class DatabaseConnectionPoolParameter implements IDatabaseConnectionPoolParameter, Serializable {

--- a/model/src/main/java/org/pentaho/database/model/DatabaseType.java
+++ b/model/src/main/java/org/pentaho/database/model/DatabaseType.java
@@ -13,7 +13,7 @@
 
 package org.pentaho.database.model;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;

--- a/model/src/main/java/org/pentaho/database/model/PartitionDatabaseMeta.java
+++ b/model/src/main/java/org/pentaho/database/model/PartitionDatabaseMeta.java
@@ -15,7 +15,7 @@ package org.pentaho.database.model;
 
 import java.io.Serializable;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Class to contain the information needed to parition (cluster): id, hostname, port, database


### PR DESCRIPTION
This pull request updates the codebase to replace `javax.xml.bind` annotations with `jakarta.xml.bind` annotations across multiple files. This change ensures compatibility with newer versions of Jakarta EE, which has replaced Java EE.

### Migration from `javax.xml.bind` to `jakarta.xml.bind`:

* [`gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseConnectionList.java`](diffhunk://#diff-f5d5bdf81da8377191fc64b2dfe4aae78d1f2dd708d59c082b5550fd8874bdb6L18-R19): Replaced `javax.xml.bind.annotation.XmlElement` and `javax.xml.bind.annotation.XmlRootElement` with `jakarta.xml.bind.annotation.XmlElement` and `jakarta.xml.bind.annotation.XmlRootElement`.
* [`gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseConnectionPoolParameterList.java`](diffhunk://#diff-90ae15921a5493ae8821141311a5d123020e339239b05605e52d7968fa0532e9L18-R19): Updated imports to use `jakarta.xml.bind.annotation.XmlElement` and `jakarta.xml.bind.annotation.XmlRootElement` instead of their `javax.xml.bind` counterparts.
* [`gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseDialectList.java`](diffhunk://#diff-82d390c9a42dd1b48777321a5063140c78f2f09ee9f65c6f493c2736bccbf353L18-R19): Migrated from `javax.xml.bind.annotation.XmlAnyElement` and `javax.xml.bind.annotation.XmlRootElement` to `jakarta.xml.bind.annotation.XmlAnyElement` and `jakarta.xml.bind.annotation.XmlRootElement`.
* [`gwt/src/main/java/org/pentaho/ui/database/event/DefaultDatabaseTypesList.java`](diffhunk://#diff-5878a3c713acef4504ecf156514d39679f2d9045b87ab208d0da2a3ed9b568adL18-R19): Switched `javax.xml.bind.annotation.XmlElement` and `javax.xml.bind.annotation.XmlRootElement` to their `jakarta.xml.bind` equivalents.

### Updates in database model classes:

* [`model/src/main/java/org/pentaho/database/model/DatabaseConnection.java`](diffhunk://#diff-4cc57f9ba62b7217c09266c82a2cb7568b7a135b35a743e18d28f553e73be6a4L26-R27): Changed `javax.xml.bind.annotation.XmlElement` and `javax.xml.bind.annotation.XmlRootElement` to `jakarta.xml.bind.annotation.XmlElement` and `jakarta.xml.bind.annotation.XmlRootElement`.
* [`model/src/main/java/org/pentaho/database/model/DatabaseConnectionPoolParameter.java`](diffhunk://#diff-78e689cff1cf746082349c24cdccf4faed782b876f626ea15bcab94d345c14dfL18-R18): Replaced `javax.xml.bind.annotation.XmlRootElement` with `jakarta.xml.bind.annotation.XmlRootElement`.
* [`model/src/main/java/org/pentaho/database/model/DatabaseType.java`](diffhunk://#diff-d884a23a24328b8ffd6a26ed05746cb4418134ffb5446b8a72af547e8b956a00L16-R16): Updated `javax.xml.bind.annotation.XmlRootElement` to `jakarta.xml.bind.annotation.XmlRootElement`.
* [`model/src/main/java/org/pentaho/database/model/PartitionDatabaseMeta.java`](diffhunk://#diff-c64f783f89df72bb2a0deb225927f3a80d6e90638fc7d2f8940d7cb4335cd71aL18-R18): Migrated from `javax.xml.bind.annotation.XmlRootElement` to `jakarta.xml.bind.annotation.XmlRootElement`.