### PR TITLE
build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -43,9 +43,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
 


### PR DESCRIPTION
**⚠️ Merge only after https://github.com/pentaho/maven-parent-poms/pull/761 has been merged ⚠️** 

This pull request updates the `pom.xml` files to improve compatibility with the latest GWT project structure and plugin management. The most important changes focus on updating dependencies to use the new `org.gwtproject` group and switching to a more specific plugin version property.

Dependency updates:

* Changed the group ID for the `gwt-user`, and `gwt-dev` dependencies from `com.google.gwt` to `org.gwtproject` to align with the latest GWT project organization.

Plugin configuration:

* Updated the `gwt-maven-plugin` version reference to use the `${gwt-maven-plugin.version}` property instead of `${gwt.version}`, improving clarity and maintainability of plugin version management.