### PR TITLE
build[SP-6878]: update GWT dependencies to use org.gwtproject groupId (#294)

### DIFF
--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -115,7 +115,7 @@
 
     <!-- third party dependencies -->
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
 
@@ -234,7 +234,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>test</scope>
     </dependency>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -43,9 +43,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
 


### PR DESCRIPTION
* build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId (https://github.com/pentaho/pentaho-commons-database/pull/294)