### PR TITLE
FUSE-562 Integrate CMS with pentaho-server's connection repository.

### DIFF
--- a/model/src/main/java/org/pentaho/database/model/DatabaseConnection.java
+++ b/model/src/main/java/org/pentaho/database/model/DatabaseConnection.java
@@ -14,22 +14,19 @@
 package org.pentaho.database.model;
 
 import com.google.gwt.core.shared.GwtIncompatible;
-import org.apache.commons.codec.binary.StringUtils;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.pentaho.database.util.Const;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class DatabaseConnection implements Serializable, IDatabaseConnection {
 
-  private static final long serialVersionUID = -3816140282186728714L;
+  private static final long serialVersionUID = -3536617472795421491L;
 
   public static final String EMPTY_OPTIONS_STRING = "><EMPTY><"; //$NON-NLS-1$
 
@@ -43,6 +40,8 @@ public class DatabaseConnection implements Serializable, IDatabaseConnection {
   String id;
 
   String name;
+
+  String connectionId;
 
   String databaseName;
 
@@ -205,6 +204,26 @@ public class DatabaseConnection implements Serializable, IDatabaseConnection {
    */
   public String getName() {
     return name;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.database.model.IDatabaseConnection#setConnectionId(java.lang.String)
+   */
+  @Override
+  public void setConnectionId(  String connectionId ) {
+    this.connectionId = connectionId;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.pentaho.database.model.IDatabaseConnection#getConnectionId()
+   */
+  @Override
+  public String getConnectionId() {
+    return connectionId;
   }
 
   /*
@@ -656,6 +675,7 @@ public class DatabaseConnection implements Serializable, IDatabaseConnection {
   private String encodeProperties() {
     StringBuilder sb = new StringBuilder();
     sb.append( encodeAttribute( "name=", name ) );
+    sb.append( encodeAttribute( "connectionId=", connectionId ) );
     sb.append( encodeAttribute( "databaseName=", databaseName ) );
     sb.append( encodeAttribute( "databasePort=", databasePort ) );
     sb.append( encodeAttribute( "hostname=", hostname ) );
@@ -716,7 +736,7 @@ public class DatabaseConnection implements Serializable, IDatabaseConnection {
 
   @Override
   public String toString() {
-    return "DatabaseConnection [id=" + id + ", name=" + name + ", databaseName=" + databaseName + ", databasePort="
+    return "DatabaseConnection [id=" + id + ", name=" + name + ", connectionId=" + connectionId + ", databaseName=" + databaseName + ", databasePort="
       + databasePort + ", hostname=" + hostname + ", username=" + username + ", password=*****"
       + ", dataTablespace=" + dataTablespace + ", indexTablespace=" + indexTablespace + ", streamingResults="
       + streamingResults + ", quoteAllFields=" + quoteAllFields + ", changed=" + changed

--- a/model/src/main/java/org/pentaho/database/model/IDatabaseConnection.java
+++ b/model/src/main/java/org/pentaho/database/model/IDatabaseConnection.java
@@ -45,6 +45,19 @@ public interface IDatabaseConnection extends Serializable {
 
   String getName();
 
+  /**
+   * Set the connection-management-service's connection Id.
+   *
+   * @param connectionId
+   *            connection Id.
+   */
+  void setConnectionId( String connectionId );
+
+  /**
+   * @return connection-management-service's connection Id.
+   */
+  String getConnectionId();
+
   void setHostname( String hostname );
 
   String getHostname();

--- a/model/src/test/java/org/pentaho/database/model/DatabaseConnectionTest.java
+++ b/model/src/test/java/org/pentaho/database/model/DatabaseConnectionTest.java
@@ -34,4 +34,14 @@ public class DatabaseConnectionTest {
     Assert.assertEquals( null, connection.getDatabaseName() );
     Assert.assertEquals( "default", connection.getDatabaseName() );
   }
+
+  @Test
+  public void testGetConnectionId() {
+    IDatabaseConnection connection = new DatabaseConnection();
+    connection.setConnectionId( "test" );
+    Assert.assertEquals( "test", connection.getConnectionId() );
+
+    String str = connection.toString();
+    Assert.assertTrue( str.contains( "connectionId=test" ) );
+  }
 }


### PR DESCRIPTION
### [FUSE-562](https://hv-eng.atlassian.net/browse/FUSE-562)

In order to add support of the [connection-management-service](https://github.com/pentaho/connection-management-service)'s connections to the data-access service, we need to add a new field to the request payload which will specify the connection Id from the connection-management-service. This Id will later be used to retrieve actual connection metadata and perform requested operations.

### What was changed?

Added new field to the IDatabaseConnection interface and to the DatabaseConnection implementation class.

[FUSE-562]: https://hv-eng.atlassian.net/browse/FUSE-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ