### PR TITLE
fix[FUSE-562] Integrate CMS with pentaho-server's connection repository

### DIFF
--- a/model/src/main/java/org/pentaho/database/model/IDatabaseConnection.java
+++ b/model/src/main/java/org/pentaho/database/model/IDatabaseConnection.java
@@ -51,12 +51,16 @@ public interface IDatabaseConnection extends Serializable {
    * @param connectionId
    *            connection Id.
    */
-  void setConnectionId( String connectionId );
+  default void setConnectionId( String connectionId ) {
+    // default implementation
+  }
 
   /**
    * @return connection-management-service's connection Id.
    */
-  String getConnectionId();
+  default String getConnectionId() {
+    return null;
+  }
 
   void setHostname( String hostname );
 


### PR DESCRIPTION
Fix to the previous [PR](https://github.com/pentaho/pentaho-commons-database/pull/306). Now new methods in the IDatabaseConnection are declared as default so depending implementations will not be affected by the update.